### PR TITLE
Bugfix in loading random wide trigger

### DIFF
--- a/src/manager/NoiseManager/NoiseManager.cc
+++ b/src/manager/NoiseManager/NoiseManager.cc
@@ -162,7 +162,7 @@ void NoiseManager::GetNextNoiseEvent()
     fCurrentEntry++; fNoiseEventHits.Clear();
     if (fCurrentEntry < fNEntries) {
         fNoiseTree->GetEntry(fCurrentEntry);
-        if (fHeader->idtgsk != mT2KDummy && fHeader->idtgsk != mRandomWide)
+        if (fHeader->idtgsk != mT2KDummy && (fHeader->idtgsk & mRandomWide) != mRandomWide)
             GetNextNoiseEvent();
         else
             SetNoiseEventHits();


### PR DESCRIPTION
I got segmentation faults with commit 22e0089 when I read the random wide trigger. Relating  to the commit 7a0fa73321. This part might be required. After this patch, the issue was disappeared.

I checked about like this stroke:
`AddNoise -in {input_rootfile} -out {some_file} -noise_type ../../../realtime/rndm:82013 -NOISESEED 42 -TNOISESTART -5 -TNOISEEND 35 -repeat_noise true`.