### PR TITLE
Update PMTHitCluster.cc

### DIFF
--- a/src/var/PMTHitCluster/PMTHitCluster.cc
+++ b/src/var/PMTHitCluster/PMTHitCluster.cc
@@ -187,7 +187,7 @@ HitReductionResult PMTHitCluster::RemoveBadChannels(Float tMin, Float tMax)
 {
     HitReductionResult res = {.nRemoved=0};
 
-    if (fElement.empty()) res;
+    if (fElement.empty()) return res;
 
     auto idCut = [](PMTHit const & hit){ return (hit.i() > MAXPM) ||
                                                 (combad_.ibad[hit.i()-1] > 0) ||


### PR DESCRIPTION
Simply fixing a problem, probably a typo.
If fElement is empty, "PMTHitCluster::RemoveBadChannels()" clashes at line 198.
The function is designed to quit before the line.