### PR TITLE
Impremented force_prompt_vertex option

### DIFF
--- a/src/manager/EventNTagManager/EventNTagManager.hh
+++ b/src/manager/EventNTagManager/EventNTagManager.hh
@@ -147,6 +147,7 @@ class EventNTagManager
         // NTag settings
         Store fSettings;
         VertexMode fPromptVertexMode, fDelayedVertexMode;
+        bool fForcePromptVertex;
         float PVXRES, PVXBIAS;
         Float T0TH, T0MX, TWIDTH, TCANWIDTH, TMINPEAKSEP, TMATCHWINDOW, TRBNWIDTH, PMTDEADTIME;
         int NHITSTH, NHITSMX, N200TH, N200MX, MINNHITS, MAXNHITS;


### PR DESCRIPTION
There is a request to force the prompt vertex in NHit calculation and so on even if ``-delayed_vertex bonsai`` is specified to reonstruct delayed vertex with bonsai and so on.