### PR TITLE
LOWE specific function to override parameters of delayed vertex

### DIFF
--- a/src/manager/EventNTagManager/EventNTagManager.cc
+++ b/src/manager/EventNTagManager/EventNTagManager.cc
@@ -722,7 +722,7 @@ void EventNTagManager::ApplySettings()
     }
 
     fForcePromptVertex = false;
-    if( fSettings.HasKey("force_prompt_vertex") ) fForcePromptVertex = true;
+    if( fSettings.GetBool("force_prompt_vertex") ) fForcePromptVertex = true;
 
     fSettings.Get("TRMSTWIDTH", TRMSTWIDTH);
     fSettings.Get("INITGRIDWIDTH", INITGRIDWIDTH);

--- a/src/manager/EventNTagManager/EventNTagManager.cc
+++ b/src/manager/EventNTagManager/EventNTagManager.cc
@@ -1107,7 +1107,7 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
     TVector3 delayedVertex = fPromptVertex;
 
     Float delayedTime = firstHit.t() + TWIDTH/2.;
-    Float delayedTimeNotReconstructed = delayedTime;
+    const Float delayedTimeNotReconstructed = delayedTime;
     float delayedGoodness = 0;
 
     bool doFit = true;
@@ -1165,7 +1165,7 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
     Float lastCandidateTime = fEventCandidates.GetSize() ? fEventCandidates.Last().Get("FitT")*1e3 + 1000 : std::numeric_limits<Float>::lowest();
     // fitted time should not be too far off from the first hit time
     // to prevent double counting of same hits
-    Float_t tmpDelayedTimeForHitSlice = fForcePromptVertex? delayedTimeNotReconstructed : delayedTime;
+    const Float_t tmpDelayedTimeForHitSlice = fForcePromptVertex? delayedTimeNotReconstructed : delayedTime;
     if (fabs(tmpDelayedTimeForHitSlice-firstHit.t()) < TMINPEAKSEP &&
         fabs(tmpDelayedTimeForHitSlice-lastCandidateTime) > TMINPEAKSEP &&
         T0TH < tmpDelayedTimeForHitSlice && tmpDelayedTimeForHitSlice < T0MX) {
@@ -1193,6 +1193,9 @@ void EventNTagManager::FindFeatures(Candidate& candidate, Float canTime)
 {
     //unsigned int firstHitID = candidate.HitID();
     //float fitTime = candidate.Get("FitT")*1e3 + 1000;
+
+    const auto delayedVertex = fEventHits.GetVertex();
+    if ( fForcePromptVertex) fEventHits.SetVertex( fPromptVertex);
     auto hitsInTCANWIDTH = fEventHits.SliceRange(canTime, -TCANWIDTH/2.-0.03, TCANWIDTH/2.);
     auto hitsIn30ns      = fEventHits.SliceRange(canTime,                -15,          +15);
     auto hitsIn50ns      = fEventHits.SliceRange(canTime,                -25,          +25);
@@ -1219,7 +1222,6 @@ void EventNTagManager::FindFeatures(Candidate& candidate, Float canTime)
     //candidate.Set("NBackHits", nBackHits);
 
     // Delayed vertex
-    auto delayedVertex = fEventHits.GetVertex();
     candidate.Set("fvx", delayedVertex.x());
     candidate.Set("fvy", delayedVertex.y());
     candidate.Set("fvz", delayedVertex.z());

--- a/src/manager/EventNTagManager/EventNTagManager.cc
+++ b/src/manager/EventNTagManager/EventNTagManager.cc
@@ -1159,7 +1159,7 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
 
     //if (doFit || fSettings.GetBool("correct_tof")) {
     fEventHits.SetVertex(delayedVertex);
-    firstHit.SetToFAndDirection( fForcePromptVertex? promptVertex : delayedVertex );
+    firstHit.SetToFAndDirection( fForcePromptVertex? fPromptVertex : delayedVertex );
     //}
 
     Float lastCandidateTime = fEventCandidates.GetSize() ? fEventCandidates.Last().Get("FitT")*1e3 + 1000 : std::numeric_limits<Float>::lowest();

--- a/src/manager/EventNTagManager/EventNTagManager.cc
+++ b/src/manager/EventNTagManager/EventNTagManager.cc
@@ -1158,8 +1158,8 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
     }
 
     //if (doFit || fSettings.GetBool("correct_tof")) {
-    fEventHits.SetVertex(delayedVertex);
-    firstHit.SetToFAndDirection( fForcePromptVertex? fPromptVertex : delayedVertex );
+    fEventHits.SetVertex(        fForcePromptVertex? fPromptVertex : delayedVertex);
+    firstHit.SetToFAndDirection( fForcePromptVertex? fPromptVertex : delayedVertex);
     //}
 
     Float lastCandidateTime = fEventCandidates.GetSize() ? fEventCandidates.Last().Get("FitT")*1e3 + 1000 : std::numeric_limits<Float>::lowest();
@@ -1181,7 +1181,7 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
             candidate.Set("BSenergy", fBonsaiManager.GetFitEnergy());
             candidate.Set("BSdirks", fBonsaiManager.GetFitDirKS());
             candidate.Set("BSovaq", fBonsaiManager.GetFitOvaQ());
-            FindFeatures(candidate, tmpDelayedTimeForHitSlice);
+            FindFeatures(candidate, tmpDelayedTimeForHitSlice, delayedVertex);
             fEventCandidates.Append(candidate);
         }
     }
@@ -1189,13 +1189,11 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
     ResetEventHitsVertex();
 }
 
-void EventNTagManager::FindFeatures(Candidate& candidate, Float canTime)
+void EventNTagManager::FindFeatures(Candidate& candidate, Float canTime, const TVector3 &delayedVertex)
 {
     //unsigned int firstHitID = candidate.HitID();
     //float fitTime = candidate.Get("FitT")*1e3 + 1000;
 
-    const auto delayedVertex = fEventHits.GetVertex();
-    if ( fForcePromptVertex) fEventHits.SetVertex( fPromptVertex);
     auto hitsInTCANWIDTH = fEventHits.SliceRange(canTime, -TCANWIDTH/2.-0.03, TCANWIDTH/2.);
     auto hitsIn30ns      = fEventHits.SliceRange(canTime,                -15,          +15);
     auto hitsIn50ns      = fEventHits.SliceRange(canTime,                -25,          +25);

--- a/src/manager/EventNTagManager/EventNTagManager.hh
+++ b/src/manager/EventNTagManager/EventNTagManager.hh
@@ -113,7 +113,7 @@ class EventNTagManager
         void FindDelayedCandidate(unsigned int iHit);
 
         // feature extraction
-        void FindFeatures(Candidate& candidate, Float canTime);
+        void FindFeatures(Candidate& candidate, Float canTime, const TVector3 &delayedVertex);
 
         // reference run for bad channels and dark rates
         void FindReferenceRun();

--- a/src/manager/EventNTagManager/EventNTagManager.hh
+++ b/src/manager/EventNTagManager/EventNTagManager.hh
@@ -147,6 +147,7 @@ class EventNTagManager
         // NTag settings
         Store fSettings;
         VertexMode fPromptVertexMode, fDelayedVertexMode;
+        bool fForcePromptVertex;
         float PVXRES, PVXBIAS;
         Float T0TH, T0MX, TWIDTH, TCANWIDTH, TMINPEAKSEP, TMATCHWINDOW, TRBNWIDTH, PMTDEADTIME;
         int NHITSTH, NHITSMX, N200TH, N200MX, MINNHITS, MAXNHITS;

--- a/src/manager/EventNTagManager/NTagGlobal.hh
+++ b/src/manager/EventNTagManager/NTagGlobal.hh
@@ -63,6 +63,6 @@ static std::vector<std::string> gCmdOptions = {"force_flat", "outdata", "write_b
                                                "TMINPEAKSEP", "TMATCHWINDOW",
                                                "TRMSTWIDTH", "INITGRIDWIDTH", "MINGRIDWIDTH", "GRIDSHRINKRATE", "VTXMAXRADIUS",
                                                "E_CUTS", "N_CUTS",
-                                               "print", "commit", "tag", "mode"};
+                                               "print", "commit", "tag", "mode", "force_prompt_vertex"};
 
 #endif


### PR DESCRIPTION
This should be merged after #38 .

This is prepared in order to realize the function of Kanemura-san. This enables to fix ``DWall`` and ``DWallMeanDir`` with the prompt vertex. In addition, it holds switching of behavior of ``DPrompt`` when the deleyed reconstructed timing is off window.