### PR TITLE
Preparation of card for lowe tmva analysis

### DIFF
--- a/card/lowe_tmva_2023dec.card
+++ b/card/lowe_tmva_2023dec.card
@@ -1,0 +1,21 @@
+correct_tof    true
+delayed_vertex lowfit
+TWIDTH         14
+NHITSTH        7
+NHITSMX        400
+N200MX         1000
+TMINPEAKSEP    50
+TCANWIDTH      14
+MINNHITS       7
+MAXNHITS       400
+TMATCHWINDOW   50
+NN_type        tmva
+weight         default
+SKOPTN         31,30,25
+SKBADOPT       55
+REFRUNNO       0
+PMTDEADTIME    900
+E_CUTS         (TagOut>0.7)&&(NHits>50)&&(FitT<20)
+N_CUTS         (TagOut>0.7)&&((NHits<50)||(FitT>20))
+force_prompt_vertex true
+override_delayed_parameters_more_for_lowe

--- a/src/manager/EventNTagManager/EventNTagManager.cc
+++ b/src/manager/EventNTagManager/EventNTagManager.cc
@@ -723,6 +723,8 @@ void EventNTagManager::ApplySettings()
 
     fForcePromptVertex = false;
     if( fSettings.GetBool("force_prompt_vertex") ) fForcePromptVertex = true;
+    fOverrideDelayedParametersMoreForLOWE = false;
+    if( fSettings.GetBool("override_delayed_parameters_more_for_lowe") ) fOverrideDelayedParametersMoreForLOWE = true;
 
     fSettings.Get("TRMSTWIDTH", TRMSTWIDTH);
     fSettings.Get("INITGRIDWIDTH", INITGRIDWIDTH);
@@ -1182,6 +1184,17 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
             candidate.Set("BSdirks", fBonsaiManager.GetFitDirKS());
             candidate.Set("BSovaq", fBonsaiManager.GetFitOvaQ());
             FindFeatures(candidate, tmpDelayedTimeForHitSlice, delayedVertex);
+            if ( fOverrideDelayedParametersMoreForLOWE ) { // This is prepared in order to reflect prompt vertex to DWall, DWallMeandir 
+              if (fabs(delayedTime-firstHit.t()) < TMINPEAKSEP &&
+                  fabs(delayedTime-lastCandidateTime) > TMINPEAKSEP &&
+                  T0TH < delayedTime && delayedTime < T0MX)
+                candidate.Set("DPrompt", -1.0);
+              auto hitsInTCANWIDTH = fEventHits.SliceRange(tmpDelayedTimeForHitSlice, -TCANWIDTH/2.-0.03, TCANWIDTH/2.);
+              auto dirVec = hitsInTCANWIDTH[HitFunc::Dir];
+              auto meanDir = GetMean(dirVec).Unit();
+              candidate.Set("DWall", GetDWall(fPromptVertex));
+              candidate.Set("DWallMeanDir", GetDWallInDirection(fPromptVertex, meanDir));
+            }
             fEventCandidates.Append(candidate);
         }
     }

--- a/src/manager/EventNTagManager/EventNTagManager.cc
+++ b/src/manager/EventNTagManager/EventNTagManager.cc
@@ -722,7 +722,7 @@ void EventNTagManager::ApplySettings()
     }
 
     fForcePromptVertex = false;
-    if( fSettings.HasKey("force_prompt_vertex") ) fForcePromptVertex = true;
+    if( fSettings.GetBool("force_prompt_vertex") ) fForcePromptVertex = true;
 
     fSettings.Get("TRMSTWIDTH", TRMSTWIDTH);
     fSettings.Get("INITGRIDWIDTH", INITGRIDWIDTH);

--- a/src/manager/EventNTagManager/EventNTagManager.cc
+++ b/src/manager/EventNTagManager/EventNTagManager.cc
@@ -1107,7 +1107,7 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
     TVector3 delayedVertex = fPromptVertex;
 
     Float delayedTime = firstHit.t() + TWIDTH/2.;
-    Float delayedTimeNotReconstructed = delayedTime;
+    const Float delayedTimeNotReconstructed = delayedTime;
     float delayedGoodness = 0;
 
     bool doFit = true;
@@ -1165,7 +1165,7 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
     Float lastCandidateTime = fEventCandidates.GetSize() ? fEventCandidates.Last().Get("FitT")*1e3 + 1000 : std::numeric_limits<Float>::lowest();
     // fitted time should not be too far off from the first hit time
     // to prevent double counting of same hits
-    Float_t tmpDelayedTimeForHitSlice = fForcePromptVertex? delayedTimeNotReconstructed : delayedTime;
+    const Float_t tmpDelayedTimeForHitSlice = fForcePromptVertex? delayedTimeNotReconstructed : delayedTime;
     if (fabs(tmpDelayedTimeForHitSlice-firstHit.t()) < TMINPEAKSEP &&
         fabs(tmpDelayedTimeForHitSlice-lastCandidateTime) > TMINPEAKSEP &&
         T0TH < tmpDelayedTimeForHitSlice && tmpDelayedTimeForHitSlice < T0MX) {
@@ -1193,6 +1193,9 @@ void EventNTagManager::FindFeatures(Candidate& candidate, Float canTime)
 {
     //unsigned int firstHitID = candidate.HitID();
     //float fitTime = candidate.Get("FitT")*1e3 + 1000;
+
+    const auto delayedVertex = fEventHits.GetVertex();
+    if ( fForcePromptVertex) fEventHits.SetVertex( fPromptVertex);
     auto hitsInTCANWIDTH = fEventHits.SliceRange(canTime, -TCANWIDTH/2.-0.03, TCANWIDTH/2.);
     auto hitsIn30ns      = fEventHits.SliceRange(canTime,                -15,          +15);
     auto hitsIn50ns      = fEventHits.SliceRange(canTime,                -25,          +25);
@@ -1219,7 +1222,6 @@ void EventNTagManager::FindFeatures(Candidate& candidate, Float canTime)
     //candidate.Set("NBackHits", nBackHits);
 
     // Delayed vertex
-    auto delayedVertex = fEventHits.GetVertex();
     candidate.Set("fvx", delayedVertex.x());
     candidate.Set("fvy", delayedVertex.y());
     candidate.Set("fvz", delayedVertex.z());

--- a/src/manager/EventNTagManager/EventNTagManager.cc
+++ b/src/manager/EventNTagManager/EventNTagManager.cc
@@ -1159,7 +1159,7 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
 
     //if (doFit || fSettings.GetBool("correct_tof")) {
     fEventHits.SetVertex(delayedVertex);
-    firstHit.SetToFAndDirection( fForcePromptVertex? promptVertex : delayedVertex );
+    firstHit.SetToFAndDirection( fForcePromptVertex? fPromptVertex : delayedVertex );
     //}
 
     Float lastCandidateTime = fEventCandidates.GetSize() ? fEventCandidates.Last().Get("FitT")*1e3 + 1000 : std::numeric_limits<Float>::lowest();

--- a/src/manager/EventNTagManager/EventNTagManager.cc
+++ b/src/manager/EventNTagManager/EventNTagManager.cc
@@ -1158,8 +1158,8 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
     }
 
     //if (doFit || fSettings.GetBool("correct_tof")) {
-    fEventHits.SetVertex(delayedVertex);
-    firstHit.SetToFAndDirection( fForcePromptVertex? fPromptVertex : delayedVertex );
+    fEventHits.SetVertex(        fForcePromptVertex? fPromptVertex : delayedVertex);
+    firstHit.SetToFAndDirection( fForcePromptVertex? fPromptVertex : delayedVertex);
     //}
 
     Float lastCandidateTime = fEventCandidates.GetSize() ? fEventCandidates.Last().Get("FitT")*1e3 + 1000 : std::numeric_limits<Float>::lowest();
@@ -1181,7 +1181,7 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
             candidate.Set("BSenergy", fBonsaiManager.GetFitEnergy());
             candidate.Set("BSdirks", fBonsaiManager.GetFitDirKS());
             candidate.Set("BSovaq", fBonsaiManager.GetFitOvaQ());
-            FindFeatures(candidate, tmpDelayedTimeForHitSlice);
+            FindFeatures(candidate, tmpDelayedTimeForHitSlice, delayedVertex);
             fEventCandidates.Append(candidate);
         }
     }
@@ -1189,13 +1189,11 @@ void EventNTagManager::FindDelayedCandidate(unsigned int iHit)
     ResetEventHitsVertex();
 }
 
-void EventNTagManager::FindFeatures(Candidate& candidate, Float canTime)
+void EventNTagManager::FindFeatures(Candidate& candidate, Float canTime, const TVector3 &delayedVertex)
 {
     //unsigned int firstHitID = candidate.HitID();
     //float fitTime = candidate.Get("FitT")*1e3 + 1000;
 
-    const auto delayedVertex = fEventHits.GetVertex();
-    if ( fForcePromptVertex) fEventHits.SetVertex( fPromptVertex);
     auto hitsInTCANWIDTH = fEventHits.SliceRange(canTime, -TCANWIDTH/2.-0.03, TCANWIDTH/2.);
     auto hitsIn30ns      = fEventHits.SliceRange(canTime,                -15,          +15);
     auto hitsIn50ns      = fEventHits.SliceRange(canTime,                -25,          +25);

--- a/src/manager/EventNTagManager/EventNTagManager.hh
+++ b/src/manager/EventNTagManager/EventNTagManager.hh
@@ -113,7 +113,7 @@ class EventNTagManager
         void FindDelayedCandidate(unsigned int iHit);
 
         // feature extraction
-        void FindFeatures(Candidate& candidate, Float canTime);
+        void FindFeatures(Candidate& candidate, Float canTime, const TVector3 &delayedVertex);
 
         // reference run for bad channels and dark rates
         void FindReferenceRun();

--- a/src/manager/EventNTagManager/EventNTagManager.hh
+++ b/src/manager/EventNTagManager/EventNTagManager.hh
@@ -148,6 +148,7 @@ class EventNTagManager
         Store fSettings;
         VertexMode fPromptVertexMode, fDelayedVertexMode;
         bool fForcePromptVertex;
+        bool fOverrideDelayedParametersMoreForLOWE;
         float PVXRES, PVXBIAS;
         Float T0TH, T0MX, TWIDTH, TCANWIDTH, TMINPEAKSEP, TMATCHWINDOW, TRBNWIDTH, PMTDEADTIME;
         int NHITSTH, NHITSMX, N200TH, N200MX, MINNHITS, MAXNHITS;

--- a/src/manager/EventNTagManager/EventNTagManager.hh
+++ b/src/manager/EventNTagManager/EventNTagManager.hh
@@ -147,6 +147,7 @@ class EventNTagManager
         // NTag settings
         Store fSettings;
         VertexMode fPromptVertexMode, fDelayedVertexMode;
+        bool fForcePromptVertex;
         float PVXRES, PVXBIAS;
         Float T0TH, T0MX, TWIDTH, TCANWIDTH, TMINPEAKSEP, TMATCHWINDOW, TRBNWIDTH, PMTDEADTIME;
         int NHITSTH, NHITSMX, N200TH, N200MX, MINNHITS, MAXNHITS;

--- a/src/manager/EventNTagManager/NTagGlobal.hh
+++ b/src/manager/EventNTagManager/NTagGlobal.hh
@@ -63,6 +63,6 @@ static std::vector<std::string> gCmdOptions = {"force_flat", "outdata", "write_b
                                                "TMINPEAKSEP", "TMATCHWINDOW",
                                                "TRMSTWIDTH", "INITGRIDWIDTH", "MINGRIDWIDTH", "GRIDSHRINKRATE", "VTXMAXRADIUS",
                                                "E_CUTS", "N_CUTS",
-                                               "print", "commit", "tag", "mode", "force_prompt_vertex"};
+                                               "print", "commit", "tag", "mode", "force_prompt_vertex", "override_prompt_vertex_more_for_lowe"};
 
 #endif

--- a/src/manager/EventNTagManager/NTagGlobal.hh
+++ b/src/manager/EventNTagManager/NTagGlobal.hh
@@ -63,6 +63,6 @@ static std::vector<std::string> gCmdOptions = {"force_flat", "outdata", "write_b
                                                "TMINPEAKSEP", "TMATCHWINDOW",
                                                "TRMSTWIDTH", "INITGRIDWIDTH", "MINGRIDWIDTH", "GRIDSHRINKRATE", "VTXMAXRADIUS",
                                                "E_CUTS", "N_CUTS",
-                                               "print", "commit", "tag", "mode"};
+                                               "print", "commit", "tag", "mode", "force_prompt_vertex"};
 
 #endif


### PR DESCRIPTION
This add new card in order to apply the newly added options such as ``force_prompt_vertex`` and ``override_delayed_parameter_more_for_lowe``.  Towards SK-VI full DSNB analysis, we plan to use it as the default mode.