### PR TITLE
Change in generating git.c

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,6 +3,8 @@ include include.gmk
 
 .PHONY: all float dirs inc clean cleanobj main docs
 
+FLAGGIT := $(shell [ -e .git ] && echo "ON" || echo "OFF")
+
 all: float obj/main/git.o inc main
 	@echo "[NTagLib] Done!"
 
@@ -17,10 +19,16 @@ dirs:
 inc: dirs
 	@cp `find src/ -name '*.hh'` include
 
-main/git.c: .git/HEAD .git/index
+main/git.c:
+ifeq ($(FLAGGIT),ON)
 	@echo "const char *gitdate = \"$(shell git show -s --format=%ci)\";" >> $@
 	@echo "const char *gitcommit = \"$(shell git rev-parse HEAD)\";" >> $@
 	@echo "const char *gittag = \"$(shell git describe --tags)\";" >> $@
+else
+	@echo "const char *gitdate = \"N/A\";" >> $@
+	@echo "const char *gitcommit = \"N/A\";" >> $@
+	@echo "const char *gittag = \"N/A\";" >> $@
+endif
 
 include/%.hh:
 	@:


### PR DESCRIPTION
This tries to resolve the issue #34 . And I also encountered the issus when I include this repository as the git-submodule because it does not hold ``.git/HEAD`` and ``.git/index`` and it just make reference via a usual file ``.git``. 

This is the algorithm to check the environment is under the maintainance of git or not
1. check the existence of ``.git`` (not to check if it is a usual file or directory): resolve the issue in the git-submodule
1-a. if not found, it replaces with "N/A"
1-b, if found, no change in the contents of ``main/git.c``

