### PR TITLE
Support of updates of ATMPD/NEUT library

### DIFF
--- a/include.gmk
+++ b/include.gmk
@@ -8,6 +8,7 @@ FCFLAGS += -w -fPIC -lstdc++
 
 SKOFL_ROOT = /usr/local/sklib_gcc8/skofl-trunk
 ATMPD_ROOT = /usr/local/sklib_gcc8/atmpd-trunk
+NEUT_ROOT = /usr/local/sklib_gcc8/neut_5.4.0.1.rev634.t2ksk
 ROOTSYS = /usr/local/sklib_gcc8/root_v5.34.38
 CERN_ROOT = /usr/local/sklib_gcc8/cern/2005
 TF_ROOT = /disk02/usr6/han/apps/tensorflow_cc-v2.5.0-cpu
@@ -19,7 +20,7 @@ SKOFLLIB = -L $(SKOFL_ROOT)/lib -lgeom -lskrd -lastro -lzbs -lgeom -lsklib -llib
 ATMPDINCLUDE = -I $(ATMPD_ROOT)/include -I $(ATMPD_ROOT)/src/analysis/neutron/ntag_gd -I $(ATMPD_ROOT)/src/recon/fitqun
 ATMPDLIB = -L $(ATMPD_ROOT)/lib -lapdrlib -lhutl -laplib -lringlib -ltp -ltf -lringlib \
 		   -laplib -lmsfit -lseplib -lmslib -lseplib -lmsfit -lprtlib -lmuelib \
-		   -lffit -lodlib -lstmu -laplowe -laplib -lfiTQun -ltf -lmslib -llelib -lntuple_t2k -lNtag
+		   -lffit -lodlib -lstmu -laplowe -laplib -lfiTQun -ltf -lmslib -llelib -lntuple_t2k -lNtag -L$(NEUT_ROOT)/lib -lzbsfns_5.4.0
 
 ROOTINCLUDE = -I $(TMVASYS)/inc -I $(ROOTSYS)/include
 ROOTLIB = -L $(ROOTSYS)/lib -lTMVA -lCore -lCint -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lTree -lRint -lPostscript -lMatrix -lPhysics -lMathCore -lThread -pthread -lm -ldl -rdynamic -lMinuit -lXMLIO -lMLP -lTreePlayer -lUnuran -lEG

--- a/include.gmk
+++ b/include.gmk
@@ -7,8 +7,7 @@ FC = gfortran
 FCFLAGS += -w -fPIC -lstdc++
 
 SKOFL_ROOT = /usr/local/sklib_gcc8/skofl-trunk
-ATMPD_ROOT = /usr/local/sklib_gcc8/atmpd-trunk
-NEUT_ROOT = /usr/local/sklib_gcc8/neut_5.4.0.1.rev634.t2ksk
+ATMPD_ROOT = /usr/local/sklib_gcc8/atmpd_23b
 ROOTSYS = /usr/local/sklib_gcc8/root_v5.34.38
 CERN_ROOT = /usr/local/sklib_gcc8/cern/2005
 TF_ROOT = /disk02/usr6/han/apps/tensorflow_cc-v2.5.0-cpu
@@ -20,7 +19,7 @@ SKOFLLIB = -L $(SKOFL_ROOT)/lib -lgeom -lskrd -lastro -lzbs -lgeom -lsklib -llib
 ATMPDINCLUDE = -I $(ATMPD_ROOT)/include -I $(ATMPD_ROOT)/src/analysis/neutron/ntag_gd -I $(ATMPD_ROOT)/src/recon/fitqun
 ATMPDLIB = -L $(ATMPD_ROOT)/lib -lapdrlib -lhutl -laplib -lringlib -ltp -ltf -lringlib \
 		   -laplib -lmsfit -lseplib -lmslib -lseplib -lmsfit -lprtlib -lmuelib \
-		   -lffit -lodlib -lstmu -laplowe -laplib -lfiTQun -ltf -lmslib -llelib -lntuple_t2k -lNtag -L$(NEUT_ROOT)/lib -lzbsfns_5.4.0
+		   -lffit -lodlib -lstmu -laplowe -laplib -lfiTQun -ltf -lmslib -llelib -lntuple_t2k -lNtag
 
 ROOTINCLUDE = -I $(TMVASYS)/inc -I $(ROOTSYS)/include
 ROOTLIB = -L $(ROOTSYS)/lib -lTMVA -lCore -lCint -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lTree -lRint -lPostscript -lMatrix -lPhysics -lMathCore -lThread -pthread -lm -ldl -rdynamic -lMinuit -lXMLIO -lMLP -lTreePlayer -lUnuran -lEG

--- a/include.gmk
+++ b/include.gmk
@@ -6,14 +6,15 @@ CXXFLAGS += -std=c++11 -fPIC -g -O0 -lgfortran -Wl,-z -Wl,muldefs
 FC = gfortran
 FCFLAGS += -w -fPIC -lstdc++
 
-SKOFL_ROOT = /usr/local/sklib_gcc8/skofl-trunk
+SKOFL_ROOT = /usr/local/sklib_gcc8/skofl_23b
+RFA_ROOT = /usr/local/sklib_gcc8/skofl-trunk/src/rfa_dummy
 ATMPD_ROOT = /usr/local/sklib_gcc8/atmpd_23b
 ROOTSYS = /usr/local/sklib_gcc8/root_v5.34.38
 CERN_ROOT = /usr/local/sklib_gcc8/cern/2005
 TF_ROOT = /disk02/usr6/han/apps/tensorflow_cc-v2.5.0-cpu
 
 SKOFLINCLUDE = -I $(SKOFL_ROOT)/include -I $(SKOFL_ROOT)/include/lowe -I $(SKOFL_ROOT)/lowe/bonsai -I $(SKOFL_ROOT)/skonl -I $(SKOFL_ROOT)/src/softtrg
-SKOFLLIB = -L $(SKOFL_ROOT)/lib -lgeom -lskrd -lastro -lzbs -lgeom -lsklib -llibrary -liolib -L $(SKOFL_ROOT)/src/rfa_dummy -lrfa -L $(SKOFL_ROOT)/lib -lmon \
+SKOFLLIB = -L $(SKOFL_ROOT)/lib -lgeom -lskrd -lastro -lzbs -lgeom -lsklib -llibrary -liolib -L$(RFA_ROOT) -lrfa -L $(SKOFL_ROOT)/lib -lmon \
 								-lskroot -lDataDefinition -ltqrealroot -lloweroot -latmpdroot -lmcinfo -lsofttrgroot -lidod_xtlk_root -lsnevtinfo\
 								-lbonsai_3.3 -lsklowe_7.0 -lwtlib_5.1 -lsollib_4.0 -lskrd -llibrary -liolib -lsklib -L /disk02/usr6/han/skofl-custom/lib -lsofttrg
 ATMPDINCLUDE = -I $(ATMPD_ROOT)/include -I $(ATMPD_ROOT)/src/analysis/neutron/ntag_gd -I $(ATMPD_ROOT)/src/recon/fitqun


### PR DESCRIPTION
Recently, the ATMPD library stops the support of ``nerdnebk`` routine. This is moved to the NEUT library. This patch is countermeasure against to this change.

According to local discussion with the maintainer of NEUT, it is better to use tagged version. So, this stop to use trunk version of ATMPD library.