### PR TITLE
Randomizing first-read-entry of dummy noise TChain

### DIFF
--- a/docs/doxygen/cloption.md
+++ b/docs/doxygen/cloption.md
@@ -89,6 +89,7 @@ The following are also valid options for [AddNoise](#addnoise-exe), where `-add_
 |`-TNOISEEND`     | Noise addition end time from event trigger (µs)                        | 536                            |
 |`-NOISESEED`     | Random seed                                                            | 0                              |
 |`-PMTDEADTIME`   | Artificial PMT deadtime (ns)                                           | 1000                           |
+|`-RANDOMIZENOISE`| Randomize the starting entry of noise tree. `false`: Read from 1st ent.| `true`                         |
 
 When `-add_noise true` option is used, dark noise hits randomly extracted from dummy trigger data files stored in the path specified by `-noise_path` (`/disk02/calib3/usr/han/dummy` by default) are appended to the input SK MC before signal search starts. Note that `-NOISESEED 0` (which is default) will set a seed used in the random number generator according to the current UNIX time.
 

--- a/src/manager/NoiseManager/NoiseManager.cc
+++ b/src/manager/NoiseManager/NoiseManager.cc
@@ -38,7 +38,7 @@ NoiseManager::NoiseManager()
   fCurrentEntry(-1), fNEntries(0),
   fPartID(0), fNParts(2),
   fCurrentPartStartTime(-1000e3), fCurrentPartEndTime(1000e3),
-  fDoRepeat(true), fDoN200Cut(false),
+	fDoRepeat(true), fDoN200Cut(false), fDoRandomizeFirstEntry(true), fRandomizedFirstEntry(-1),
   fMsg("NoiseManager")
 {}
 
@@ -68,6 +68,8 @@ void NoiseManager::DumpSettings()
     if (fNoiseTree) {
         fMsg.Print(Form("Noise type: " + fNoiseType));
         fMsg.Print(Form("Total dummy trigger entries: %d", fNoiseTree->GetEntries(fNoiseCut)));
+		fMsg.Print(Form("Randomized starting entry? : %s", (fDoRandomizeFirstEntry ? "yes" : "no")));
+		fMsg.Print(Form("Dummy trgger starting entry: %d", (fRandomizedFirstEntry == -1 ? 0 : fRandomizedFirstEntry)));
         fMsg.Print(Form("Repetition allowed? %s", (fDoRepeat ? "yes" : "no")));
         if (fDoN200Cut) fMsg.Print(Form("Noise MaxN200: %d (ID), %d (OD)", fIDMaxN200, fODMaxN200));
     }
@@ -113,7 +115,27 @@ void NoiseManager::SetNoiseTree(TChain* tree)
     fHeader = 0; fNoiseTree->SetBranchAddress("HEADER", &fHeader);
     fNEntries = fNoiseTree->GetEntries();
 
-    fNoiseTree->GetEntry();
+	if (fDoRandomizeFirstEntry == true)
+	{
+	    auto random = ranGen.Uniform();
+	    long randomized_ent = (long) ((double)ceil(fNEntries*random));
+		fRandomizedFirstEntry = randomized_ent-1;
+		int ret = fNoiseTree->GetEntry(fRandomizedFirstEntry);
+		//fMsg.Print(Form("Randomize TChain starting entry: %d", fDoRandomizeFirstEntry));
+		//fMsg.Print(Form("             Total TChain entry: %d", fNEntries));
+		//fMsg.Print(Form("          TChain starting entry: %d", fNoiseTree->GetReadEntry()));
+		//fMsg.Print(Form("                         random: %g", random));
+		//fMsg.Print(Form("                 randomized_ent: %d", randomized_ent));
+		if ( ret == 0 )
+		{
+			fMsg.Print("Something wrong at: NoiseManager::SetNoiseTree()", pERROR);
+		}
+	}
+	else
+	{
+		fNoiseTree->GetEntry(0);
+	}
+
 }
 
 void NoiseManager::DumpNoiseFileList(TString pathToList)
@@ -271,11 +293,13 @@ void NoiseManager::ApplySettings(Store& settings, int nInputEvents)
     //auto pmtDeadtime = settings.GetFloat("PMTDEADTIME", 900);
     float pmtDeadtime = 900;
     auto debug       = settings.GetBool("debug", false);
+	auto randomizeNoise = settings.GetBool("RANDOMIZENOISE", true);
 
     SetSKGeneration(skGen);
     SetSeed(noiseSeed);
     SetNoiseMaxN200(idMaxN200, odMaxN200, doN200Cut);
     SetPMTDeadtime(pmtDeadtime);
+	SetRandomizeFirstEntry(randomizeNoise);
     if (debug) SetVerbosity(pDEBUG);
     if (noiseType == "simulate") {
         SetDarkRate(idDarkRate, odDarkRate);
@@ -385,6 +409,10 @@ void NoiseManager::AddNoise(PMTHitCluster* signalHits, PMTHitCluster* noiseHits,
     // noise from noise files
     if (fNoiseTree) {
         if (fCurrentEntry == -1 || fPartID == fNParts) {
+			if (fDoRandomizeFirstEntry && fCurrentEntry == -1 && fRandomizedFirstEntry != -1) {
+				fCurrentEntry = fRandomizedFirstEntry - 1;
+				fRandomizedFirstEntry = -1; // Change the fCurrentEntry, only for the first time.
+			}
             GetNextNoiseEvent();
         }
         //std::cout << "NoiseHitsSize: " << noiseHits->GetSize() << "\n";

--- a/src/manager/NoiseManager/NoiseManager.hh
+++ b/src/manager/NoiseManager/NoiseManager.hh
@@ -35,6 +35,7 @@ class NoiseManager
         void SetRepeat(bool b) { fDoRepeat = b; }
         void SetSeed(int seed) { fNoiseSeed = seed; ranGen.SetSeed(seed); }
         void SetSKGeneration(int gen) { fSKGen = gen; }
+        void SetRandomizeFirstEntry(bool b) { fDoRandomizeFirstEntry = b; }
         void DumpSettings();
 
         // noise tree generation
@@ -105,6 +106,9 @@ class NoiseManager
         float fCurrentPartStartTime, fCurrentPartEndTime;
 
         bool fDoRepeat, fDoN200Cut;
+
+		bool fDoRandomizeFirstEntry;
+		int  fRandomizedFirstEntry;
 
         //std::vector<float> fT, fQ;
         //std::vector<int>   fI;


### PR DESCRIPTION
This commit introduce a new function: randomization of the first-read-entry of dummy noise TChain.
* Previously, dummy noise TChain was read from the first entry every time. When only a few root files are available as the dummy noise data, only a small part of data will be used repeatedly.

Following option is newly added for this function:  -RANDOMIZENOISE
Default value is "true", i.e. randomization will be done by default.